### PR TITLE
Don't warn on "variable X exported from 'case'"

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,15 +5,16 @@
 ]}.
 
 {erl_opts, [
-  debug_info, 
-  compressed, 
-  report, 
-  warn_export_all, 
-  warn_export_vars, 
-  warn_shadow_vars, 
-  warn_unused_function, 
-  warn_deprecated_function, 
-  warn_obsolete_guard, 
-  warn_unused_import 
-%  warnings_as_errors
+  debug_info,
+  compressed,
+  report,
+  warn_export_all,
+  warn_export_vars,
+  warn_shadow_vars,
+  warn_unused_function,
+  warn_deprecated_function,
+  warn_obsolete_guard,
+  warn_unused_import,
+  nowarn_export_vars
+% warnings_as_errors
 ]}.


### PR DESCRIPTION
Added `nowarn_export_vars`

The variable escaping the case is deliberate, as stated in the comment linked below. The best solution is therefore to ignore the warning.

Link: https://github.com/jbrisbin/rabbit_common/blob/master/src/credit_flow.erl#L59
