### PR TITLE
Remove mirrored_supervisor from erl_first_files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,6 @@
 {erl_first_files, [
   "src/supervisor2.erl",
-  "src/gen_server2.erl",
-  "src/mirrored_supervisor.erl"
+  "src/gen_server2.erl"
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
Module mirrored_supervisor in erl_first_files cause compilation errors on some systems due to rebar feature. Rebar does not depend on order of files in erl_first_files list but on order of files in list returned by filelib:fold_files/5. Since no one module of rabbit_common project depends on mirrored_supervisor we can remove it from erl_first_files list without any consequences.
