### PR TITLE
rename mochijson2

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -1003,7 +1003,7 @@ sequence_error([_ | Rest])               -> sequence_error(Rest).
 
 json_encode(Term) ->
     try
-        {ok, mochijson2:encode(Term)}
+        {ok, rc_mochijson2:encode(Term)}
     catch
         exit:{json_encode, E} ->
             {error, E}
@@ -1011,7 +1011,7 @@ json_encode(Term) ->
 
 json_decode(Term) ->
     try
-        {ok, mochijson2:decode(Term)}
+        {ok, rc_mochijson2:decode(Term)}
     catch
         %% Sadly `mochijson2:decode/1' does not offer a nice way to catch
         %% decoding errors...

--- a/src/rc_mochijson2.erl
+++ b/src/rc_mochijson2.erl
@@ -41,7 +41,7 @@
 %%          </li>
 %%      </ul>
 
--module(mochijson2).
+-module(rc_mochijson2).
 -author('bob@mochimedia.com').
 -export([encoder/1, encode/1]).
 -export([decoder/1, decode/1, decode/2]).
@@ -699,7 +699,7 @@ encoder_utf8_test() ->
         encode(<<1,"\321\202\320\265\321\201\321\202">>),
 
     %% raw utf8 output (optional)
-    Enc = mochijson2:encoder([{utf8, true}]),
+    Enc = rc_mochijson2:encoder([{utf8, true}]),
     [34,"\\u0001",[209,130],[208,181],[209,129],[209,130],34] =
         Enc(<<1,"\321\202\320\265\321\201\321\202">>).
 


### PR DESCRIPTION
we should not copy code form other repos with the same name so at least rename it.
i do not want to put whole mochiweb as a dependancy intentionally.
Otherwise it's not possible to use both rabbit_common and original mochiweb 
