### PR TITLE
using os:timestamp/0 since erlang:now/0 is deprecated

### DIFF
--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -116,7 +116,7 @@ state() -> case blocked() of
                true  -> flow;
                false -> case get(credit_blocked_at) of
                             undefined -> running;
-                            B         -> Diff = timer:now_diff(erlang:now(), B),
+                            B         -> Diff = timer:now_diff(os:timestamp(), B),
                                          case Diff < 5000000 of
                                              true  -> flow;
                                              false -> running
@@ -144,7 +144,7 @@ grant(To, Quantity) ->
 
 block(From) ->
     case blocked() of
-        false -> put(credit_blocked_at, erlang:now());
+        false -> put(credit_blocked_at, os:timestamp());
         true  -> ok
     end,
     ?UPDATE(credit_blocked, [], Blocks, [From | Blocks]).

--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -623,7 +623,7 @@ unregister_name(_Name) -> ok.
 extend_backoff(undefined) ->
     undefined;
 extend_backoff({backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod}) ->
-    {backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod, now()}.
+    {backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod, os:timestamp()}.
 
 %%%========================================================================
 %%% Internal functions
@@ -687,7 +687,7 @@ wake_hib(GS2State = #gs2_state { timeout_state = TS }) ->
                         undefined ->
                             undefined;
                         {SleptAt, TimeoutState} ->
-                            adjust_timeout_state(SleptAt, now(), TimeoutState)
+                            adjust_timeout_state(SleptAt, os:timestamp(), TimeoutState)
                     end,
     post_hibernate(
       drain(GS2State #gs2_state { timeout_state = TimeoutState1 })).
@@ -695,7 +695,7 @@ wake_hib(GS2State = #gs2_state { timeout_state = TS }) ->
 hibernate(GS2State = #gs2_state { timeout_state = TimeoutState }) ->
     TS = case TimeoutState of
              undefined             -> undefined;
-             {backoff, _, _, _, _} -> {now(), TimeoutState}
+             {backoff, _, _, _, _} -> {os:timestamp(), TimeoutState}
          end,
     proc_lib:hibernate(?MODULE, wake_hib,
                        [GS2State #gs2_state { timeout_state = TS }]).

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -461,7 +461,7 @@ handle_pre_hibernate(State) ->
     ok = clear_permission_cache(),
     rabbit_event:if_enabled(
       State, #ch.stats_timer,
-      fun () -> emit_stats(State, [{idle_since, now()}]) end),
+      fun () -> emit_stats(State, [{idle_since, os:timestamp()}]) end),
     {hibernate, rabbit_event:stop_stats_timer(State, #ch.stats_timer)}.
 
 terminate(Reason, State) ->

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -803,7 +803,7 @@ gb_trees_foreach(Fun, Tree) ->
     gb_trees_fold(fun (Key, Val, Acc) -> Fun(Key, Val), Acc end, ok, Tree).
 
 now_ms() ->
-    timer:now_diff(now(), {0,0,0}) div 1000.
+    timer:now_diff(os:timestamp(), {0,0,0}) div 1000.
 
 module_attributes(Module) ->
     case catch Module:module_info(attributes) of

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -490,7 +490,7 @@ maybe_block(State = #v1{connection_state = blocking,
     State1 = State#v1{connection_state = blocked,
                       throttle = update_last_blocked_by(
                                    Throttle#throttle{
-                                     last_blocked_at = erlang:now()})},
+                                     last_blocked_at = os:timestamp()})},
     case {blocked_by_alarm(State), blocked_by_alarm(State1)} of
         {false, true} -> ok = send_blocked(State1);
         {_,        _} -> ok
@@ -1176,7 +1176,7 @@ i(state, #v1{connection_state = ConnectionState,
         (credit_flow:blocked() %% throttled by flow now
          orelse                %% throttled by flow recently
            (WasBlockedBy =:= flow andalso T =/= never andalso
-            timer:now_diff(erlang:now(), T) < 5000000)) of
+            timer:now_diff(os:timestamp(), T) < 5000000)) of
         true  -> flow;
         false -> ConnectionState
     end;

--- a/src/supervisor2.erl
+++ b/src/supervisor2.erl
@@ -1492,7 +1492,7 @@ add_restart(State) ->
     I = State#state.intensity,
     P = State#state.period,
     R = State#state.restarts,
-    Now = erlang:now(),
+    Now = os:timestamp(),
     R1 = add_restart([Now|R], Now, P),
     State1 = State#state{restarts = R1},
     case length(R1) of


### PR DESCRIPTION
Hello,

This replaces the call to erlang:now/0 (now fully deprecated) with a call to os:timestamp/0.

Any thoughts?

Thanks in advance!