### PR TITLE
specify xmerl in application dependency list

### DIFF
--- a/src/rabbit_common.app.src
+++ b/src/rabbit_common.app.src
@@ -4,4 +4,4 @@
   {modules, []},
   {registered, []},
   {env, []},
-  {applications, [kernel, stdlib]}]}.
+  {applications, [kernel, stdlib, xmerl]}]}.


### PR DESCRIPTION
With regards to the issue https://github.com/jbrisbin/amqp_client/issues/26, I created a PR which specifies xmerl application as dependency.