### PR TITLE
replaced erlang's random library with the new rand

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -767,7 +767,7 @@ adjust_timeout_state(SleptAt, AwokeAt, {backoff, CurrentTO, MinimumTO,
             true -> lists:max([MinimumTO, CurrentTO div 2]);
             false -> CurrentTO
         end,
-    {Extra, RandomState1} = random:uniform_s(Base, RandomState),
+    {Extra, RandomState1} = rand:uniform_s(Base, RandomState),
     CurrentTO1 = Base + Extra,
     {backoff, CurrentTO1, MinimumTO, DesiredHibPeriod, RandomState1}.
 

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -909,7 +909,7 @@ pget_or_die(K, P) ->
         V         -> V
     end.
 
-%% property merge 
+%% property merge
 pmerge(Key, Val, List) ->
       case proplists:is_defined(Key, List) of
               true -> List;
@@ -919,9 +919,9 @@ pmerge(Key, Val, List) ->
 %% proplists merge
 plmerge(P1, P2) ->
     dict:to_list(dict:merge(fun(_, V, _) ->
-                                V 
-                            end, 
-                            dict:from_list(P1), 
+                                V
+                            end,
+                            dict:from_list(P1),
                             dict:from_list(P2))).
 
 pset(Key, Value, List) -> [{Key, Value} | proplists:delete(Key, List)].
@@ -1166,12 +1166,12 @@ moving_average(Time,  HalfLife,  Next, Current) ->
 random(N) ->
     case get(random_seed) of
         undefined ->
-            random:seed(erlang:phash2([node()]),
+            rand:seed(exsplus, {erlang:phash2([node()]),
                         time_compat:monotonic_time(),
-                        time_compat:unique_integer());
+                        time_compat:unique_integer()});
         _ -> ok
     end,
-    random:uniform(N).
+    rand:uniform(N).
 
 %% Moved from rabbit/src/rabbit_cli.erl
 %% If the server we are talking to has non-standard net_ticktime, and


### PR DESCRIPTION
Compiling on Erlang/OTP 19 yield the following deprecation warnings:

```
===> Compiling rabbit_common
./deps/rabbit_common/src/gen_server2.erl:770: Warning: random:uniform_s/2: the 'random' module is deprecated; use the 'rand' module instead
src/gen_server2.erl:770: Warning: random:uniform_s/2: the 'random' module is deprecated; use the 'rand' module instead

./deps/rabbit_common/src/rabbit_misc.erl:1169: Warning: random:seed/3: the 'random' module is deprecated; use the 'rand' module instead
./deps/rabbit_common/src/rabbit_misc.erl:1174: Warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
src/rabbit_misc.erl:1169: Warning: random:seed/3: the 'random' module is deprecated; use the 'rand' module instead
src/rabbit_misc.erl:1174: Warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
```

The pull request replaces the deprecated _random_ module with the new _rand_ module.