### PR TITLE
Namespace mochijson2 to avoid collision with mochiweb

### DIFF
--- a/src/rabbit_common_mochijson2.erl
+++ b/src/rabbit_common_mochijson2.erl
@@ -41,7 +41,7 @@
 %%          </li>
 %%      </ul>
 
--module(mochijson2).
+-module(rabbit_common_mochijson2).
 -author('bob@mochimedia.com').
 -export([encoder/1, encode/1]).
 -export([decoder/1, decode/1, decode/2]).
@@ -699,7 +699,7 @@ encoder_utf8_test() ->
         encode(<<1,"\321\202\320\265\321\201\321\202">>),
 
     %% raw utf8 output (optional)
-    Enc = mochijson2:encoder([{utf8, true}]),
+    Enc = rabbit_common_mochijson2:encoder([{utf8, true}]),
     [34,"\\u0001",[209,130],[208,181],[209,129],[209,130],34] =
         Enc(<<1,"\321\202\320\265\321\201\321\202">>).
 

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -909,7 +909,7 @@ pget_or_die(K, P) ->
         V         -> V
     end.
 
-%% property merge 
+%% property merge
 pmerge(Key, Val, List) ->
       case proplists:is_defined(Key, List) of
               true -> List;
@@ -919,9 +919,9 @@ pmerge(Key, Val, List) ->
 %% proplists merge
 plmerge(P1, P2) ->
     dict:to_list(dict:merge(fun(_, V, _) ->
-                                V 
-                            end, 
-                            dict:from_list(P1), 
+                                V
+                            end,
+                            dict:from_list(P1),
                             dict:from_list(P2))).
 
 pset(Key, Value, List) -> [{Key, Value} | proplists:delete(Key, List)].
@@ -1038,7 +1038,7 @@ sequence_error([_ | Rest])               -> sequence_error(Rest).
 
 json_encode(Term) ->
     try
-        {ok, mochijson2:encode(Term)}
+        {ok, rabbit_common_mochijson2:encode(Term)}
     catch
         exit:{json_encode, E} ->
             {error, E}
@@ -1046,9 +1046,9 @@ json_encode(Term) ->
 
 json_decode(Term) ->
     try
-        {ok, mochijson2:decode(Term)}
+        {ok, rabbit_common_mochijson2:decode(Term)}
     catch
-        %% Sadly `mochijson2:decode/1' does not offer a nice way to catch
+        %% Sadly `rabbit_common_mochijson2:decode/1' does not offer a nice way to catch
         %% decoding errors...
         error:_ -> error
     end.


### PR DESCRIPTION
I hit a collision when using https://github.com/pma/amqp and https://github.com/philss/floki in the same project. floki relies on https://github.com/mochi/mochiweb which obviously has it's own copy of mochijson2. When performing a distillery release it fails due to the duplicated modules.

This PR resolves the issue by namespacing the mochijson2 module as rabbit_common_mochijson2